### PR TITLE
 fix: credit_summary_bar, credit_summary_rankingのAPIが正しくデータ送るように修正

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -47,12 +47,12 @@ api_bp = Blueprint('api', __name__, url_prefix='/api')
 def credit_summary_bar():
     query = (
         Regist.select(
-            User.name, 
-            fn.SUM(Subject.price).alias('total_credits')
+            User.name, #生徒名
+            fn.SUM(Subject.price).alias('total_credits') # 生徒ごとに合計単位数
         )
-        .join(User, on=(Regist.user == User.id))
-        .join(Subject, on=(Regist.subject == Subject.id))
-        .group_by(Regist.user)
+        .join(User, on=(Regist.user == User.id))  # 明示的にUserとの結合条件を指定
+        .join(Subject, on=(Regist.subject == Subject.id))  # 明示的にSubjectとの結合条件を指定
+        .group_by(Regist.user) # 生徒ごとにグループ化
         .order_by(fn.SUM(Subject.price).desc())  # 合計単位数が多い順にソート
     )
     
@@ -68,23 +68,25 @@ def credit_summary_bar():
 # 返す型はjson
 # 生徒ごとに履修合計単位数を返す
 # key=生徒名, value=その生徒の合計単位数 但し、TOP5のみ返す
-# @api_bp.route('/credit_summary_ranking', methods=['GET', 'POST'])
-# def credit_summary_ranking():
-#     query = (
-#         User.select(
-#             User.name, fn.SUM(Subject.price).alias('student_data')
-#         )
-#         .join(Regist, on=(User.name == Regist.user))
-#         .join(Subject, on=(Regist.subject == Subject.name))
-#         .group_by(User.name)
-#         .order_by(fn.SUM(Subject.price).desc())
-#     )
+@api_bp.route('/credit_summary_ranking', methods=['GET', 'POST'])
+def credit_summary_ranking():
+    # queryは上のcredit_summary_barと同じ
+    query = (
+        Regist.select(
+            User.name, 
+            fn.SUM(Subject.price).alias('total_credits')
+        )
+        .join(User, on=(Regist.user == User.id))
+        .join(Subject, on=(Regist.subject == Subject.id))
+        .group_by(Regist.user)
+        .order_by(fn.SUM(Subject.price).desc())
+    )
 
-#     # 上位5名の結果を表示
-#     students_data = {user.name: user.total_credits for user in  enumerate(query.limit(5), start=1)}
+    # 上位5名の結果を表示
+    students_data = { f'rank {rank}:{result.user.name}' : result.total_credits for rank, result in enumerate(query.limit(5), start=1)}
     
-#     result = {
-#         'labels': list(students_data.keys()),
-#         'data': list(students_data.values())
-#     }
-#     return jsonify(result)
+    result = {
+        'labels': list(students_data.keys()),
+        'data': list(students_data.values())
+    }
+    return jsonify(result)

--- a/routes/api.py
+++ b/routes/api.py
@@ -8,37 +8,38 @@ api_bp = Blueprint('api', __name__, url_prefix='/api')
 # 返す型はjson
 # 教科ごとの履修登録者を返す
 # key=教科名, value=履修者の数
-@api_bp.route('/register_summary_bar', methods=['GET', 'POST'])
-def register_summary_bar():
-    '''
-    query = (
-        Regist.select(
-            Subject.name #科目名
-        )
-        .join(Subject, on=(Subject.name == Regist.subject))  # 明示的にProductとの結合条件を指定
-        .group_by(Subject.name)  # 履修登録した生徒ごとにグループ化
-        .order_by(fn.COUNT(Regist.user))  # 履修登録した生徒数
-    )
-    '''
-    print('pass')
-    query = (
-        Regist.select(Subject.name)  # 科目名を選択
-        .join(Subject, on=(Subject.name == Regist.subject))  # 結合条件を指定
-        .group_by(Subject.name)  # 科目名でグループ化
-    )
+# @api_bp.route('/register_summary_bar', methods=['GET', 'POST'])
+# def register_summary_bar():
+#     '''
+#     query = (
+#         Regist.select(
+#             Subject.name #科目名
+#         )
+#         .join(Subject, on=(Subject.name == Regist.subject))  # 明示的にProductとの結合条件を指定
+#         .group_by(Subject.name)  # 履修登録した生徒ごとにグループ化
+#         .order_by(fn.COUNT(Regist.user))  # 履修登録した生徒数
+#     )
+#     '''
+#     print('pass')
+#     query = (
+#         Regist.select(Subject.name)  # 科目名を選択
+#         .join(Subject, on=(Subject.name == Regist.subject))  # 結合条件を指定
+#         .group_by(Subject.name)  # 科目名でグループ化
+#     )
     
-    grouped_count = len(list(query))
+#     grouped_count = len(list(query))
 
-    print(query)
-    # ここに書く
+#     print(query)
+#     # ここに書く
 
-# 返す型はjson
-# 教科ごとの履修登録者を返す
-# key=教科名, value=その科目の履修者の数 但し、TOP5のみ返す
-@api_bp.route('/register_summary_ranking', methods=['GET', 'POST'])
-def register_summary_ranking():
-    # ここに書く
-    pass
+# # 返す型はjson
+# # 教科ごとの履修登録者を返す
+# # key=教科名, value=その科目の履修者の数 但し、TOP5のみ返す
+# @api_bp.route('/register_summary_ranking', methods=['GET', 'POST'])
+# def register_summary_ranking():
+#     # ここに書く
+#     pass
+
 # 返す型はjson
 # 生徒ごとに履修合計単位数を返す
 # key=生徒名, value=その生徒の合計単位数
@@ -46,9 +47,11 @@ def register_summary_ranking():
 def credit_summary_bar():
     query = (
         Regist.select(
-            Regist.user, fn.SUM(Subject.price).alias('total_credits')
+            User.name, 
+            fn.SUM(Subject.price).alias('total_credits')
         )
-        .join(Regist, on=(Regist.subject == Subject.name))
+        .join(User, on=(Regist.user == User.id))
+        .join(Subject, on=(Regist.subject == Subject.id))
         .group_by(Regist.user)
         .order_by(fn.SUM(Subject.price).desc())  # 合計単位数が多い順にソート
     )
@@ -65,23 +68,23 @@ def credit_summary_bar():
 # 返す型はjson
 # 生徒ごとに履修合計単位数を返す
 # key=生徒名, value=その生徒の合計単位数 但し、TOP5のみ返す
-@api_bp.route('/credit_summary_ranking', methods=['GET', 'POST'])
-def credit_summary_ranking():
-    query = (
-        User.select(
-            User.name, fn.SUM(Subject.price).alias('student_data')
-        )
-        .join(Regist, on=(User.name == Regist.user))
-        .join(Subject, on=(Regist.subject == Subject.name))
-        .group_by(User.name)
-        .order_by(fn.SUM(Subject.price).desc())
-    )
+# @api_bp.route('/credit_summary_ranking', methods=['GET', 'POST'])
+# def credit_summary_ranking():
+#     query = (
+#         User.select(
+#             User.name, fn.SUM(Subject.price).alias('student_data')
+#         )
+#         .join(Regist, on=(User.name == Regist.user))
+#         .join(Subject, on=(Regist.subject == Subject.name))
+#         .group_by(User.name)
+#         .order_by(fn.SUM(Subject.price).desc())
+#     )
 
-    # 上位5名の結果を表示
-    students_data = {user.name: user.total_credits for user in  enumerate(query.limit(5), start=1)}
+#     # 上位5名の結果を表示
+#     students_data = {user.name: user.total_credits for user in  enumerate(query.limit(5), start=1)}
     
-    result = {
-        'labels': list(students_data.keys()),
-        'data': list(students_data.values())
-    }
-    return jsonify(result)
+#     result = {
+#         'labels': list(students_data.keys()),
+#         'data': list(students_data.values())
+#     }
+#     return jsonify(result)

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,6 @@
     <title>データ一覧</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='base-style.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="{{ url_for('static', filename='subject_graph.js') }}"></script>
-    <script src="{{ url_for('static', filename='user_graph.js') }}"></script>
 </head>
 <body>
     <h1>index</h1>
@@ -25,10 +23,12 @@
     </section>
     <section class="credit_summary">
       <h3>履修合計単位数</h3>
-      <canvas id="credit_summary_chart"></canvas>
+      <canvas id="credit_summary_chart" width="300"></canvas>
     <section class="credit_ranking">
       <h3>履修合計単位数(TOP5)</h3>
       <canvas id="credit_ranking_chart" width="300" height="300"></canvas>
     </section>
+    <script src="{{ url_for('static', filename='subject_graph.js') }}"></script>
+    <script src="{{ url_for('static', filename='user_graph.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## fix: credit_summary_barがデータを送るように修正
#### 行ったこと
- credit_summary_barからユーザー名と合計単位数は送られるようになった
#### 気になったこと
- jsやcssファイルのステータスレスポンスが304になってる
  - エラーではないけど、成功を意味する200ではないので気になる
  - 未更新という意味らしい(参考:https://developer.mozilla.org/ja/docs/Web/HTTP/Status/304)

## fix: credit_summary_rankingが正しく動くよう修正
#### 行ったこと
- credit_summary_rankingがエラーが発生していたのを、正しくAPIが送れるように修正した
- index.html内のjsを読み込むコードをbodyの最下部に移動した
  - 理由: head内にjsを読み込むコードが書かれていたことで、htmlが読み込まれる前にjsが読み込まれ、グラフが描画されていなかったため
  - 結果: グラフが正しく描画されるようになった